### PR TITLE
Adjust systemd service to new tear_down way to work

### DIFF
--- a/etc/microfw.service
+++ b/etc/microfw.service
@@ -4,10 +4,10 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStartPre=/var/lib/microfw/tear_down.sh
+ExecStartPre=/usr/local/sbin/microfw tear_down
 ExecStart=/var/lib/microfw/setup.sh
 RemainAfterExit=true
-ExecStop=/var/lib/microfw/tear_down.sh
+ExecStop=/usr/local/sbin/microfw tear_down
 StandardOutput=journal
 
 [Install]


### PR DESCRIPTION
It seems that the tear_down.sh will not be installed by ansible and isn't needed anymore, therefore we have to adjust the systemd as well 