### PR TITLE
In some cases the DOCKER-USER chain isn't there during boot up

### DIFF
--- a/etc/microfw.service
+++ b/etc/microfw.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=MicroFW
-After=network.target
+After=network.target docker.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Add  `docker.service` to `After` systemd list to prevent this