### PR TITLE
Swap to microfw apply_bootup function at boot time

### DIFF
--- a/etc/microfw.service
+++ b/etc/microfw.service
@@ -4,8 +4,7 @@ After=network.target docker.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/local/sbin/microfw tear_down
-ExecStart=/var/lib/microfw/setup.sh
+ExecStart=/usr/local/sbin/microfw apply_bootup
 RemainAfterExit=true
 ExecStop=/usr/local/sbin/microfw tear_down
 StandardOutput=journal

--- a/src/microfw.sh
+++ b/src/microfw.sh
@@ -22,6 +22,11 @@ if [ -z "${RUNNING_IN_CI:-}" ]; then
                 echo " show          Generate and show setup.sh, but do not write it to disk"
                 echo " compile       Update tear_down.sh and setup.sh"
                 echo " apply         compile, run setup, prompt for aliveness, run teardown on timeout"
+                echo " apply_bootup  compile, run setup"
+                echo "               Note: Be sure you have applied the last changes. They will be active"
+                echo "                     after a reboot and you won't get a chance to revert them"
+                echo "                     in case you locked yourself out. Further this function is only meant"
+                echo "                     to be called from systemd service."
                 echo " tear_down     tear down any existing rules"
                 exit 0
                 ;;
@@ -36,7 +41,7 @@ if [ -z "${RUNNING_IN_CI:-}" ]; then
                 shift
                 ;;
 
-            show|compile|apply|tear_down)
+            show|compile|apply|apply_bootup|tear_down)
                 COMMAND="$1"
                 ;;
 
@@ -161,6 +166,16 @@ function apply() {
 }
 
 
+function apply_bootup() {
+
+    rm -f $VAR_DIR/state.txt
+    rm -f $VAR_DIR/setup.sh
+
+    compile
+    $VAR_DIR/setup.sh
+
+}
+
 if [ -z "${RUNNING_IN_CI:-}" ]; then
     case "$COMMAND" in
         show)
@@ -171,6 +186,9 @@ if [ -z "${RUNNING_IN_CI:-}" ]; then
             ;;
         apply)
             apply
+            ;;
+        apply_bootup)
+            apply_bootup
             ;;
         tear_down)
             tear_down


### PR DESCRIPTION
Add apply_bootup function to reduce failures during boot up. This function removes the _state.txt_ and the _setup.sh_. Afterwards it does a fresh compile of the rules. This catches start up issues if a power loss or a crash happened or some kind of inconsistency between the rules and the generated _setup.sh_ exists. 