### PR TITLE
Move state.txt to /dev/shm to prevent boot up failure in case of a power loss

### DIFF
--- a/etc/microfw.service
+++ b/etc/microfw.service
@@ -8,6 +8,7 @@ ExecStart=/usr/local/sbin/microfw apply_bootup
 RemainAfterExit=true
 ExecStop=/usr/local/sbin/microfw tear_down
 StandardOutput=journal
+RuntimeDirectory=microfw
 
 [Install]
 WantedBy=multi-user.target

--- a/features/teardown.sh
+++ b/features/teardown.sh
@@ -34,6 +34,7 @@ function ip6tables () {
 
 RUNNING_IN_CI=true
 VAR_DIR="$TEMPDIR/var"
+SHM_DIR="$TEMPDIR/var"
 ETC_DIR="$TEMPDIR/etc"
 source src/microfw.sh
 

--- a/features/teardown.sh
+++ b/features/teardown.sh
@@ -34,7 +34,7 @@ function ip6tables () {
 
 RUNNING_IN_CI=true
 VAR_DIR="$TEMPDIR/var"
-SHM_DIR="$TEMPDIR/var"
+RUN_DIR="$TEMPDIR/run"
 ETC_DIR="$TEMPDIR/etc"
 source src/microfw.sh
 

--- a/src/generate_setup.py
+++ b/src/generate_setup.py
@@ -15,6 +15,7 @@ Rule      = namedtuple("Rule",      ["srczone", "dstzone", "srcaddr", "dstaddr",
 Virtual   = namedtuple("Virtual",   ["srczone", "extaddr", "intaddr", "extservice", "intservice", "lineno"])
 
 ETC_DIR = "/etc/microfw"
+SHM_DIR = "/dev/shm/microfw"
 
 if len(sys.argv) > 1:
     ETC_DIR = sys.argv[1]
@@ -236,7 +237,7 @@ def generate_setup(tables):
 
     def state(fmt, obj=None):
         """ generate a command to echo something into the state file """
-        printf('echo "%s" >> /var/lib/microfw/state.txt ' % fmt, obj)
+        printf('echo "%s" >> "%s"/state.txt ' % (fmt, SHM_DIR), obj)
 
     # Generate ipsets for the entries we're going to use
 
@@ -257,9 +258,9 @@ def generate_setup(tables):
             printf("ipset add    '%(name)s_udp' '%(udp)s'", service)
 
     printf("")
-    printf("rm -f /var/lib/microfw/state.txt")
-    printf("touch /var/lib/microfw/state.txt")
-    printf("chmod 600 /var/lib/microfw/state.txt")
+    printf("rm -f %s/state.txt" % SHM_DIR)
+    printf("touch %s/state.txt" % SHM_DIR)
+    printf("chmod 600 %s/state.txt" % SHM_DIR)
 
     printf("iptables  -t filter -N MFWINPUT")
     printf("ip6tables -t filter -N MFWINPUT")

--- a/src/generate_setup.py
+++ b/src/generate_setup.py
@@ -15,7 +15,7 @@ Rule      = namedtuple("Rule",      ["srczone", "dstzone", "srcaddr", "dstaddr",
 Virtual   = namedtuple("Virtual",   ["srczone", "extaddr", "intaddr", "extservice", "intservice", "lineno"])
 
 ETC_DIR = "/etc/microfw"
-SHM_DIR = "/dev/shm/microfw"
+RUN_DIR = "/run/microfw"
 
 if len(sys.argv) > 1:
     ETC_DIR = sys.argv[1]
@@ -237,7 +237,7 @@ def generate_setup(tables):
 
     def state(fmt, obj=None):
         """ generate a command to echo something into the state file """
-        printf('echo "%s" >> "%s"/state.txt ' % (fmt, SHM_DIR), obj)
+        printf('echo "%s" >> "%s"/state.txt ' % (fmt, RUN_DIR), obj)
 
     # Generate ipsets for the entries we're going to use
 
@@ -258,9 +258,9 @@ def generate_setup(tables):
             printf("ipset add    '%(name)s_udp' '%(udp)s'", service)
 
     printf("")
-    printf("rm -f %s/state.txt" % SHM_DIR)
-    printf("touch %s/state.txt" % SHM_DIR)
-    printf("chmod 600 %s/state.txt" % SHM_DIR)
+    printf("rm -f %s/state.txt" % RUN_DIR)
+    printf("touch %s/state.txt" % RUN_DIR)
+    printf("chmod 600 %s/state.txt" % RUN_DIR)
 
     printf("iptables  -t filter -N MFWINPUT")
     printf("ip6tables -t filter -N MFWINPUT")

--- a/src/microfw.sh
+++ b/src/microfw.sh
@@ -60,7 +60,7 @@ if [ -z "${RUNNING_IN_CI:-}" ]; then
 fi
 
 function tear_down() {
-    if [ ! -e "$SHM_DIR/state.txt" ]; then
+    if [ ! -e "$RUN_DIR/state.txt" ]; then
         # Already torn down -> nothing to do
         return
     fi

--- a/src/microfw.sh
+++ b/src/microfw.sh
@@ -71,8 +71,8 @@ function tear_down() {
     set +e
 
     # First let's find out if docker and mangle are present
-    HAVE_DOCKER="$(grep -q "^HAVE-DOCKER$" "$SHM_DIR/state.txt" && echo "true" || echo "false")"
-    HAVE_MANGLE="$(grep -q "^HAVE-MANGLE$" "$SHM_DIR/state.txt" && echo "true" || echo "false")"
+    HAVE_DOCKER="$(grep -q "^HAVE-DOCKER$" "$RUN_DIR/state.txt" && echo "true" || echo "false")"
+    HAVE_MANGLE="$(grep -q "^HAVE-MANGLE$" "$RUN_DIR/state.txt" && echo "true" || echo "false")"
 
     # Little helper function that makes it easier to run the same command for
     # both iptables and ip6tables
@@ -108,7 +108,7 @@ function tear_down() {
     done
 
     # Flush and drop zone-specific chains
-    grep "^ZONE " "$SHM_DIR/state.txt" | while read command zone; do
+    grep "^ZONE " "$RUN_DIR/state.txt" | while read command zone; do
         ip+6tables -t filter -F "${zone}_inp"
         ip+6tables -t filter -X "${zone}_inp"
         ip+6tables -t filter -F "${zone}_fwd"
@@ -134,7 +134,7 @@ function tear_down() {
     ipset flush
     ipset destroy
 
-    rm "$SHM_DIR/state.txt"
+    rm "$RUN_DIR/state.txt"
     set -e
 }
 


### PR DESCRIPTION
Move state.txt into RAM to make microfw more robust against power loss or system crashes. 

This PR is stacked on top of #9 , so it depend on it

Fixes #6